### PR TITLE
feat: refactor scrapers to use APIs + add GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+    paths: ["web/**"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: web
+        run: pnpm install
+
+      - name: Build
+        working-directory: web
+        run: pnpm build

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,40 @@
+name: Scrape Hackathons
+
+on:
+  schedule:
+    - cron: "0 12 * * 1,4" # Lunes y jueves a las 12 UTC
+  workflow_dispatch: {} # Trigger manual
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        working-directory: scraper
+        run: uv sync
+
+      - name: Install Playwright browsers
+        working-directory: scraper
+        run: uv run playwright install chromium
+
+      - name: Run scraper pipeline
+        working-directory: scraper
+        env:
+          X_AUTH_TOKEN: ${{ secrets.X_AUTH_TOKEN }}
+          X_CT0: ${{ secrets.X_CT0 }}
+        run: uv run hackathons-scrape pipeline --output ../web/src/data/hackathons.json
+
+      - name: Commit updated data
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "data: update hackathons.json [automated]"
+          file_pattern: web/src/data/hackathons.json

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-dateutil>=2.8",
     "thefuzz[speedup]>=0.20",
     "structlog>=23.0",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/scraper/src/scrapers/luma.py
+++ b/scraper/src/scrapers/luma.py
@@ -1,84 +1,168 @@
 from __future__ import annotations
 
 from datetime import datetime
-from urllib.parse import quote_plus
 
+import httpx
 import structlog
 
-from src.config import LUMA_QUERIES, MAX_SCROLLS_PER_QUERY, PAGE_LOAD_TIMEOUT_MS
 from src.models import RawEvent
 from src.scrapers.base import BaseScraper
 
 logger = structlog.get_logger()
 
+# Known Luma hackathon URLs and search queries to find more
+SEED_URLS = [
+    "https://lu.ma/4uq8yejo",  # Midnight Hackathon Buenos Aires
+    "https://lu.ma/fizpni10",  # HackAvax Road to Avalanche Summit Argentina
+    "https://lu.ma/6kluo21l",  # Hack Day Based Argentina Weekend
+    "https://lu.ma/do4zysjd",  # Bitcoin Virtual Hackathon
+    "https://lu.ma/e12138qh",  # Hackathon @Aleph de Verano
+    "https://lu.ma/m1vu0bde",  # AI Hackathon: Model Routing | BAISH
+    "https://lu.ma/uds2l1td",  # Aleph Hackaton @ Aleph March '25
+]
+
+HACKATHON_KEYWORDS = [
+    "hackathon", "hackatón", "hackaton", "datathon", "buildathon",
+    "ideathon", "codeathon", "game jam", "startup weekend", "code jam",
+    "hack day", "hack week",
+]
+
+ARGENTINA_KEYWORDS = [
+    "argentina", "buenos aires", "córdoba", "cordoba", "rosario",
+    "mendoza", "tucumán", "tucuman", "la plata", "bariloche",
+]
+
 
 class LumaScraper(BaseScraper):
-    BASE_URL = "https://lu.ma/search"
+    """Scraper that fetches Luma events via their URL API + discover feed."""
+
+    URL_API = "https://api.lu.ma/url"
+    DISCOVER_API = "https://api.lu.ma/discover/get-paginated-events"
+
+    async def _fetch_event(self, client: httpx.AsyncClient, event_url: str) -> RawEvent | None:
+        """Fetch a single event by its Luma URL slug."""
+        slug = event_url.rstrip("/").split("/")[-1]
+        try:
+            resp = await client.get(self.URL_API, params={"url": slug})
+            if resp.status_code != 200:
+                return None
+
+            data = resp.json()
+            event = data.get("data", {}).get("event", {})
+            if not event:
+                return None
+
+            name = event.get("name", "")
+            geo = event.get("geo_address_info") or {}
+            city = geo.get("city", "")
+            country = geo.get("country", "")
+            address = geo.get("address", "")
+            start = event.get("start_at", "")
+            end = event.get("end_at", "")
+            timezone = event.get("timezone", "")
+            location_type = event.get("location_type", "")
+            description_raw = event.get("description_mirror")
+            description_md = str(description_raw)[:500] if description_raw else ""
+
+            parts = [name]
+            if start:
+                parts.append(f"Fecha: {start[:10]}")
+            if end and end[:10] != start[:10]:
+                parts.append(f"Fin: {end[:10]}")
+            if city:
+                parts.append(f"Ciudad: {city}")
+            if country:
+                parts.append(f"Pais: {country}")
+            if address:
+                parts.append(f"Lugar: {address}")
+            if location_type:
+                parts.append(f"Tipo: {location_type}")
+            if timezone:
+                parts.append(f"Zona: {timezone}")
+            if description_md:
+                parts.append(description_md)
+
+            full_url = f"https://lu.ma/{slug}"
+
+            return RawEvent(
+                source="luma",
+                raw_text=" | ".join(parts),
+                url=full_url,
+                scraped_at=datetime.now(),
+            )
+
+        except Exception:
+            logger.debug("luma.fetch_error", url=event_url, exc_info=True)
+            return None
+
+    async def _discover_events(self, client: httpx.AsyncClient) -> list[str]:
+        """Scan discover feed for hackathon-like events in Argentina."""
+        urls: list[str] = []
+        cursor = None
+
+        for page in range(10):
+            params: dict = {"pagination_limit": 50}
+            if cursor:
+                params["pagination_cursor"] = cursor
+
+            try:
+                resp = await client.get(self.DISCOVER_API, params=params)
+                if resp.status_code != 200:
+                    break
+
+                data = resp.json()
+                for entry in data.get("entries", []):
+                    event = entry.get("event", entry)
+                    name = (event.get("name") or "").lower()
+                    geo = event.get("geo_address_info") or {}
+                    combined = f"{name} {(geo.get('country') or '').lower()} {(geo.get('city') or '').lower()}"
+
+                    is_hackathon = any(kw in name for kw in HACKATHON_KEYWORDS)
+                    is_argentina = any(kw in combined for kw in ARGENTINA_KEYWORDS)
+
+                    if is_hackathon and is_argentina:
+                        slug = event.get("url", "")
+                        if slug:
+                            urls.append(f"https://lu.ma/{slug}")
+
+                if not data.get("has_more"):
+                    break
+                cursor = data.get("next_cursor")
+                if not cursor:
+                    break
+
+            except Exception:
+                break
+
+        return urls
 
     async def scrape(self) -> list[RawEvent]:
-        browser = await self._launch_browser()
         events: list[RawEvent] = []
         seen_urls: set[str] = set()
 
-        try:
-            context = await browser.new_context(
-                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            )
-            page = await context.new_page()
+        headers = {
+            "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            "accept": "application/json",
+        }
 
-            for query in LUMA_QUERIES:
-                logger.info("luma.query", query=query)
-                try:
-                    url = f"{self.BASE_URL}?q={quote_plus(query)}"
-                    await page.goto(url, timeout=PAGE_LOAD_TIMEOUT_MS)
-                    await page.wait_for_timeout(3000)
+        async with httpx.AsyncClient(headers=headers, timeout=15) as client:
+            # Collect URLs from discover feed
+            discover_urls = await self._discover_events(client)
+            logger.info("luma.discover", found=len(discover_urls))
 
-                    # Scroll to load more results
-                    for _ in range(MAX_SCROLLS_PER_QUERY):
-                        await page.evaluate("window.scrollBy(0, window.innerHeight)")
-                        await page.wait_for_timeout(1500)
+            # Combine seed URLs + discovered URLs
+            all_urls = list(SEED_URLS) + discover_urls
 
-                    # Extract event cards
-                    cards = await page.query_selector_all("[class*='event-link'], a[href*='/event/']")
-                    if not cards:
-                        # Try alternative selectors
-                        cards = await page.query_selector_all("a[href^='/']")
-
-                    for card in cards:
-                        try:
-                            href = await card.get_attribute("href")
-                            if not href or "/event/" not in href:
-                                continue
-
-                            event_url = f"https://lu.ma{href}" if href.startswith("/") else href
-                            if event_url in seen_urls:
-                                continue
-                            seen_urls.add(event_url)
-
-                            text = await card.inner_text()
-                            if not text.strip():
-                                continue
-
-                            events.append(
-                                RawEvent(
-                                    source="luma",
-                                    raw_text=text.strip(),
-                                    url=event_url,
-                                    scraped_at=datetime.now(),
-                                )
-                            )
-                        except Exception:
-                            logger.debug("luma.card_error", exc_info=True)
-                            continue
-
-                    logger.info("luma.query_done", query=query, found=len(cards))
-                except Exception:
-                    logger.warning("luma.query_error", query=query, exc_info=True)
+            # Fetch each event
+            for event_url in all_urls:
+                normalized = event_url.rstrip("/").split("/")[-1]
+                if normalized in seen_urls:
                     continue
+                seen_urls.add(normalized)
 
-                await self._random_delay()
-
-        finally:
-            await browser.close()
+                event = await self._fetch_event(client, event_url)
+                if event:
+                    events.append(event)
+                    logger.info("luma.event", name=event.raw_text[:60])
 
         return events

--- a/scraper/src/scrapers/twitter.py
+++ b/scraper/src/scrapers/twitter.py
@@ -6,8 +6,9 @@ from datetime import datetime
 from urllib.parse import quote_plus
 
 import structlog
+from playwright.async_api import Page, BrowserContext
 
-from src.config import MAX_SCROLLS_PER_QUERY, PAGE_LOAD_TIMEOUT_MS, X_QUERIES
+from src.config import X_QUERIES, MAX_SCROLLS_PER_QUERY, PAGE_LOAD_TIMEOUT_MS
 from src.models import RawEvent
 from src.scrapers.base import BaseScraper
 
@@ -15,117 +16,148 @@ logger = structlog.get_logger()
 
 
 class TwitterScraper(BaseScraper):
-    BASE_URL = "https://x.com/search"
+    """Scraper that uses Playwright to automate X search and intercept GraphQL responses."""
 
-    def _get_cookies_path(self) -> str | None:
-        path = os.environ.get("X_COOKIES_PATH")
-        if path and os.path.exists(path):
-            return path
-        default = os.path.join(os.path.dirname(__file__), "..", "..", "cookies", "x_cookies.json")
-        if os.path.exists(default):
-            return default
-        return None
+    def _get_cookies(self) -> list[dict] | None:
+        """Build cookie list from env vars."""
+        auth_token = os.environ.get("X_AUTH_TOKEN")
+        ct0 = os.environ.get("X_CT0")
 
-    async def _load_cookies(self, context) -> bool:
-        cookies_path = self._get_cookies_path()
-        if not cookies_path:
-            logger.warning("twitter.no_cookies", msg="No cookies file found. X search requires authentication.")
-            return False
+        if not auth_token or not ct0:
+            logger.warning("twitter.no_credentials", msg="Set X_AUTH_TOKEN and X_CT0 env vars")
+            return None
 
-        with open(cookies_path) as f:
-            cookies = json.load(f)
+        return [
+            {"name": "auth_token", "value": auth_token, "domain": ".x.com", "path": "/"},
+            {"name": "ct0", "value": ct0, "domain": ".x.com", "path": "/"},
+        ]
 
-        await context.add_cookies(cookies)
-        logger.info("twitter.cookies_loaded", path=cookies_path)
-        return True
+    def _extract_tweets_from_response(self, data: dict) -> list[dict]:
+        """Extract tweet data from a GraphQL SearchTimeline response."""
+        tweets: list[dict] = []
+        try:
+            instructions = (
+                data.get("data", {})
+                .get("search_by_raw_query", {})
+                .get("search_timeline", {})
+                .get("timeline", {})
+                .get("instructions", [])
+            )
+            for instruction in instructions:
+                entries = instruction.get("entries", [])
+                for entry in entries:
+                    result = (
+                        entry.get("content", {})
+                        .get("itemContent", {})
+                        .get("tweet_results", {})
+                        .get("result", {})
+                    )
+                    if not result:
+                        continue
+                    if result.get("__typename") == "TweetWithVisibilityResults":
+                        result = result.get("tweet", {})
+
+                    legacy = result.get("legacy", {})
+                    full_text = legacy.get("full_text", "")
+                    if not full_text:
+                        continue
+
+                    user_legacy = (
+                        result.get("core", {})
+                        .get("user_results", {})
+                        .get("result", {})
+                        .get("legacy", {})
+                    )
+                    screen_name = user_legacy.get("screen_name")
+
+                    urls = legacy.get("entities", {}).get("urls", [])
+                    external_url = None
+                    for u in urls:
+                        expanded = u.get("expanded_url", "")
+                        if expanded and "x.com" not in expanded and "twitter.com" not in expanded:
+                            external_url = expanded
+                            break
+
+                    tweets.append({
+                        "text": full_text,
+                        "author": f"@{screen_name}" if screen_name else None,
+                        "url": external_url,
+                    })
+        except Exception:
+            logger.debug("twitter.parse_error", exc_info=True)
+
+        return tweets
 
     async def scrape(self) -> list[RawEvent]:
+        cookies = self._get_cookies()
+        if not cookies:
+            return []
+
         browser = await self._launch_browser()
         events: list[RawEvent] = []
         seen_texts: set[str] = set()
+        captured_tweets: list[dict] = []
 
         try:
-            context = await browser.new_context(
-                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            context: BrowserContext = await browser.new_context(
+                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
                 viewport={"width": 1280, "height": 900},
             )
+            await context.add_cookies(cookies)
 
-            has_cookies = await self._load_cookies(context)
-            if not has_cookies:
-                logger.warning("twitter.skip", msg="Skipping X scraper — no cookies available")
-                await browser.close()
-                return []
+            page: Page = await context.new_page()
 
-            page = await context.new_page()
+            # Intercept GraphQL responses to capture tweet data
+            async def handle_response(response):
+                if "SearchTimeline" in response.url and response.status == 200:
+                    try:
+                        data = await response.json()
+                        tweets = self._extract_tweets_from_response(data)
+                        captured_tweets.extend(tweets)
+                        logger.debug("twitter.intercepted", count=len(tweets))
+                    except Exception:
+                        pass
+
+            page.on("response", handle_response)
 
             for query in X_QUERIES:
                 logger.info("twitter.query", query=query)
+                captured_tweets.clear()
+
                 try:
-                    url = f"{self.BASE_URL}?q={quote_plus(query)}&src=typed_query&f=live"
+                    url = f"https://x.com/search?q={quote_plus(query)}&src=typed_query&f=live"
                     await page.goto(url, timeout=PAGE_LOAD_TIMEOUT_MS)
 
-                    # Wait for tweets to appear
+                    # Wait for content to load
                     try:
                         await page.wait_for_selector('[data-testid="tweet"]', timeout=15000)
                     except Exception:
                         logger.warning("twitter.no_tweets", query=query)
                         continue
 
-                    # Scroll to load more
-                    for _ in range(MAX_SCROLLS_PER_QUERY):
+                    # Scroll to trigger more API requests
+                    for _ in range(min(MAX_SCROLLS_PER_QUERY, 5)):
                         await page.evaluate("window.scrollBy(0, window.innerHeight)")
                         await page.wait_for_timeout(2000)
 
-                    # Extract tweets
-                    tweets = await page.query_selector_all('[data-testid="tweet"]')
-
-                    for tweet in tweets:
-                        try:
-                            # Get tweet text
-                            text_el = await tweet.query_selector('[data-testid="tweetText"]')
-                            if not text_el:
-                                continue
-                            text = await text_el.inner_text()
-                            if not text.strip():
-                                continue
-
-                            # Deduplicate by content
-                            text_key = text.strip()[:100]
-                            if text_key in seen_texts:
-                                continue
-                            seen_texts.add(text_key)
-
-                            # Get author
-                            author = None
-                            author_el = await tweet.query_selector('[data-testid="User-Name"] a')
-                            if author_el:
-                                author = await author_el.get_attribute("href")
-                                if author:
-                                    author = author.strip("/")
-
-                            # Get links from tweet
-                            links = await tweet.query_selector_all("a[href]")
-                            tweet_url = None
-                            for link in links:
-                                href = await link.get_attribute("href")
-                                if href and ("http" in href) and ("x.com" not in href) and ("twitter.com" not in href):
-                                    tweet_url = href
-                                    break
-
-                            events.append(
-                                RawEvent(
-                                    source="x",
-                                    raw_text=text.strip(),
-                                    url=tweet_url,
-                                    author=author,
-                                    scraped_at=datetime.now(),
-                                )
-                            )
-                        except Exception:
-                            logger.debug("twitter.tweet_error", exc_info=True)
+                    # Process captured tweets from intercepted responses
+                    for tweet in captured_tweets:
+                        text_key = tweet["text"][:100]
+                        if text_key in seen_texts:
                             continue
+                        seen_texts.add(text_key)
 
-                    logger.info("twitter.query_done", query=query, found=len(tweets))
+                        events.append(
+                            RawEvent(
+                                source="x",
+                                raw_text=tweet["text"],
+                                url=tweet["url"],
+                                author=tweet["author"],
+                                scraped_at=datetime.now(),
+                            )
+                        )
+
+                    logger.info("twitter.query_done", query=query, found=len(captured_tweets))
 
                 except Exception:
                     logger.warning("twitter.query_error", query=query, exc_info=True)

--- a/scraper/uv.lock
+++ b/scraper/uv.lock
@@ -12,6 +12,28 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -85,11 +107,21 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hackathons-scraper"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "httpx" },
     { name = "playwright" },
     { name = "pydantic" },
     { name = "python-dateutil" },
@@ -106,6 +138,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "playwright", specifier = ">=1.40" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dateutil", specifier = ">=2.8" },
@@ -117,6 +150,43 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.21" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Luma: use public API (lu.ma/url endpoint) instead of Playwright
- X/Twitter: use Playwright with GraphQL response interception
- Add httpx dependency for direct API calls
- Add GitHub Actions for automated scraping (Mon/Thu) and deploy