### PR TITLE
feat: add GitHub issues as hackathon source with auto-rebuild

### DIFF
--- a/.github/ISSUE_TEMPLATE/hackathon.yml
+++ b/.github/ISSUE_TEMPLATE/hackathon.yml
@@ -1,0 +1,97 @@
+name: Agregar hackathon
+description: Sumá un hackathon al directorio
+title: "[hackathon] "
+labels: []
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Nombre del hackathon
+      placeholder: "Ej: AI Buildathon Buenos Aires"
+    validations:
+      required: true
+
+  - type: input
+    id: date_start
+    attributes:
+      label: Fecha inicio
+      placeholder: "YYYY-MM-DD"
+    validations:
+      required: true
+
+  - type: input
+    id: date_end
+    attributes:
+      label: Fecha fin
+      placeholder: "YYYY-MM-DD (dejar vacío si es un solo día)"
+
+  - type: dropdown
+    id: country
+    attributes:
+      label: Pais
+      options:
+        - Argentina
+        - Brasil
+        - Chile
+        - Colombia
+        - Mexico
+        - Peru
+        - Uruguay
+        - Paraguay
+        - Ecuador
+        - Bolivia
+        - Venezuela
+        - Costa Rica
+        - Panama
+        - Guatemala
+        - USA
+        - Canada
+    validations:
+      required: true
+
+  - type: input
+    id: city
+    attributes:
+      label: Ciudad
+      placeholder: "Ej: Buenos Aires"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Tipo
+      options:
+        - presencial
+        - online
+        - hibrido
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Lugar
+      placeholder: "Dirección o venue (opcional)"
+
+  - type: input
+    id: url
+    attributes:
+      label: URL del evento
+      placeholder: "https://..."
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags
+      placeholder: "ai, web3, fintech (separados por coma)"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripcion
+      placeholder: "Breve descripción del evento"
+    validations:
+      required: true

--- a/.github/workflows/rebuild-on-issue.yml
+++ b/.github/workflows/rebuild-on-issue.yml
@@ -1,0 +1,13 @@
+name: Rebuild on Hackathon Issue
+
+on:
+  issues:
+    types: [opened, edited, closed, reopened]
+
+jobs:
+  trigger-deploy:
+    if: contains(github.event.issue.title, '[hackathon]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel Deploy Hook
+        run: curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -11,7 +11,7 @@ const hackathons = defineCollection({
     city: z.string().nullable(),
     location: z.string().nullable(),
     url: z.string().nullable(),
-    source: z.enum(["x", "luma"]),
+    source: z.enum(["x", "luma", "comunidad"]),
     type: z.enum(["presencial", "online", "hibrido"]).nullable(),
     tags: z.array(z.string()),
     description: z.string(),

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -117,6 +117,87 @@ async function fetchLumaEvents(): Promise<HackathonData[]> {
   return events;
 }
 
+// --- Fetch hackathon submissions from GitHub Issues ---
+// Supports two body formats:
+// 1. Terminal submit: - **Fecha**: 2026-04-16 - 2026-04-16
+// 2. GitHub issue form: ### Fecha inicio\n\n2026-04-16
+async function fetchGitHubIssues(): Promise<HackathonData[]> {
+  const events: HackathonData[] = [];
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/ainponce/hackathones/issues?state=open&per_page=100",
+      { headers: { "Accept": "application/vnd.github.v3+json", "User-Agent": "hackathones-build" } }
+    );
+    if (!res.ok) return events;
+    const issues = await res.json();
+
+    for (const issue of issues) {
+      if (issue.pull_request) continue;
+      if (!issue.title?.toLowerCase().startsWith("[hackathon]")) continue;
+      const body: string = issue.body || "";
+
+      // Format 1: - **Label**: value (from terminal submit)
+      const boldField = (label: string): string | null => {
+        const m = body.match(new RegExp(`\\*\\*${label}\\*\\*:\\s*(.+)`, "i"));
+        return m ? m[1].trim() : null;
+      };
+
+      // Format 2: ### Label\n\nvalue (from GitHub issue form)
+      const formField = (label: string): string | null => {
+        const m = body.match(new RegExp(`###\\s*${label}\\s*\\n+([^#\\n][^\\n]*)`, "i"));
+        return m ? m[1].trim() || null : null;
+      };
+
+      const field = (boldLabel: string, formLabel?: string): string | null => {
+        return boldField(boldLabel) || formField(formLabel || boldLabel) || null;
+      };
+
+      // Parse dates - handle both "Fecha: start - end" and separate "Fecha inicio"/"Fecha fin"
+      let date_start: string | null = null;
+      let date_end: string | null = null;
+      const fechaRaw = boldField("Fecha");
+      if (fechaRaw) {
+        const parts = fechaRaw.split(/\s*-\s*/);
+        date_start = parts[0]?.match(/\d{4}-\d{2}-\d{2}/)?.[0] || null;
+        date_end = parts[1]?.match(/\d{4}-\d{2}-\d{2}/)?.[0] || date_start;
+      } else {
+        const startRaw = formField("Fecha inicio");
+        const endRaw = formField("Fecha fin");
+        date_start = startRaw?.match(/\d{4}-\d{2}-\d{2}/)?.[0] || null;
+        date_end = endRaw?.match(/\d{4}-\d{2}-\d{2}/)?.[0] || date_start;
+      }
+
+      if (date_end && date_end < today) continue;
+
+      const tagsRaw = field("Tags");
+      const tags = tagsRaw ? tagsRaw.split(/,\s*/).map(t => t.trim()).filter(Boolean) : [];
+
+      // Description: ### Descripcion\n...(rest of body)
+      const descMatch = body.match(/###\s*Descripcion\s*\n+([\s\S]*?)$/i);
+      const description = descMatch ? descMatch[1].trim().slice(0, 300) : "";
+
+      const name = issue.title.replace(/^\[hackathon\]\s*/i, "").trim();
+      const id = "gh-" + issue.number;
+
+      events.push({
+        id,
+        name,
+        date_start,
+        date_end,
+        country: field("Pais"),
+        city: field("Ciudad"),
+        location: field("Lugar"),
+        url: field("URL", "URL del evento"),
+        source: "comunidad",
+        type: field("Tipo"),
+        tags,
+        description,
+      });
+    }
+  } catch { /* GitHub API unavailable */ }
+  return events;
+}
+
 let jsonEvents: HackathonData[] = [];
 try {
   const { getCollection } = await import("astro:content");
@@ -125,13 +206,48 @@ try {
 } catch { /* no local data */ }
 
 const lumaEvents = await fetchLumaEvents();
+const ghEvents = await fetchGitHubIssues();
 
-const seen = new Set(jsonEvents.map(e => e.id));
-const merged = [...jsonEvents];
-for (const e of lumaEvents) {
-  if (!seen.has(e.id)) {
+// --- Deduplication by name similarity + date proximity ---
+function normalize(s: string): string {
+  return s.toLowerCase()
+    .normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function wordSet(s: string): Set<string> {
+  return new Set(normalize(s).split(" ").filter(w => w.length > 2));
+}
+
+function nameSimilarity(a: string, b: string): number {
+  const setA = wordSet(a);
+  const setB = wordSet(b);
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let common = 0;
+  for (const w of setA) if (setB.has(w)) common++;
+  return common / Math.max(setA.size, setB.size);
+}
+
+function datesClose(a: HackathonData, b: HackathonData): boolean {
+  if (!a.date_start || !b.date_start) return true; // can't tell, assume possible match
+  const diff = Math.abs(new Date(a.date_start).getTime() - new Date(b.date_start).getTime());
+  return diff <= 3 * 86400000; // 3 days
+}
+
+function isDuplicate(event: HackathonData, existing: HackathonData[]): boolean {
+  return existing.some(e =>
+    e.id === event.id ||
+    (nameSimilarity(e.name, event.name) >= 0.5 && datesClose(e, event))
+  );
+}
+
+// Merge with priority: comunidad > luma > scraper (later sources enrich, not replace)
+const merged: HackathonData[] = [...jsonEvents];
+for (const e of [...ghEvents, ...lumaEvents]) {
+  if (!isDuplicate(e, merged)) {
     merged.push(e);
-    seen.add(e.id);
   }
 }
 


### PR DESCRIPTION
Fetch community-submitted hackathons from GitHub issues at build time, supporting both terminal submit and GitHub issue form formats. Includes fuzzy name + date deduplication across all sources.

- Add fetchGitHubIssues() in index.astro (parses issue body)
- Add rebuild-on-issue.yml workflow (triggers Vercel deploy hook)
- Add hackathon issue template form for structured submissions
- Add "comunidad" source to content collection schema