### PR TITLE
feat: add per-event calendar button to hackathon list

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -467,6 +467,45 @@ const sorted = filtered.sort((a, b) => {
       return s + " - " + e;
     }
 
+    function escIcs(text) {
+      return text.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
+    }
+
+    function downloadIcs(h) {
+      if (!h.date_start) return;
+      const dtStart = h.date_start.replace(/-/g, "");
+      const endDate = h.date_end || h.date_start;
+      const endDt = new Date(endDate + "T00:00:00");
+      endDt.setDate(endDt.getDate() + 1);
+      const dtEnd = endDt.toISOString().slice(0, 10).replace(/-/g, "");
+      const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
+
+      const lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//hackathons.ar//Hackathones//ES",
+        "BEGIN:VEVENT",
+        "UID:" + h.id + "@hackathons.ar",
+        "DTSTAMP:" + stamp,
+        "DTSTART;VALUE=DATE:" + dtStart,
+        "DTEND;VALUE=DATE:" + dtEnd,
+        "SUMMARY:" + escIcs(h.name),
+      ];
+      const loc = h.location || h.city;
+      if (loc) lines.push("LOCATION:" + escIcs(loc));
+      if (h.url) lines.push("URL:" + h.url);
+      if (h.description) lines.push("DESCRIPTION:" + escIcs(h.description));
+      lines.push("END:VEVENT", "END:VCALENDAR");
+
+      const blob = new Blob([lines.join("\r\n")], { type: "text/calendar;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      window.location.href = url;
+      setTimeout(function() { URL.revokeObjectURL(url); }, 1000);
+    }
+
+    // Store references for calendar button click handler
+    const _icsMap = {};
+
     function printEvent(h) {
       const meta = [
         formatDate(h.date_start, h.date_end),
@@ -475,13 +514,24 @@ const sorted = filtered.sort((a, b) => {
         h.type,
       ].filter(Boolean).join("  /  ");
 
+      const icsId = "ics-" + h.id;
+      _icsMap[icsId] = h;
+
       let html = '<div class="event-block">';
       html += '<div class="bold">&gt; ' + esc(h.name) + '</div>';
       html += '<div class="muted">' + esc(meta) + '</div>';
       if (h.location) html += '<div class="muted">' + esc(h.location) + '</div>';
       if (h.tags && h.tags.length) html += '<div class="muted">' + h.tags.map(t => '[' + esc(t) + ']').join(' ') + '</div>';
       if (h.description) html += '<div>' + esc(h.description) + '</div>';
-      if (h.url) html += '<div><a class="link" href="' + esc(h.url) + '" target="_blank" rel="noopener">' + esc(h.url) + '</a></div>';
+
+      let actionsHtml = '';
+      if (h.url) actionsHtml += '<a class="link" href="' + esc(h.url) + '" target="_blank" rel="noopener">' + esc(h.url) + '</a>';
+      if (h.date_start) {
+        if (actionsHtml) actionsHtml += '  ';
+        actionsHtml += '<button class="cal-btn" data-ics="' + icsId + '">[+ calendario]</button>';
+      }
+      if (actionsHtml) html += '<div>' + actionsHtml + '</div>';
+
       html += '</div>';
       print(html);
     }
@@ -968,7 +1018,16 @@ const sorted = filtered.sort((a, b) => {
       }
     });
 
-    document.addEventListener("click", () => { if (!isTyping) cmdInput.focus(); });
+    document.addEventListener("click", (e) => {
+      const btn = e.target.closest(".cal-btn");
+      if (btn) {
+        e.stopPropagation();
+        const h = _icsMap[btn.dataset.ics];
+        if (h) downloadIcs(h);
+        return;
+      }
+      if (!isTyping) cmdInput.focus();
+    });
 
     // --- Animated placeholder ---
     const phEl = document.getElementById("placeholder");

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -93,6 +93,20 @@ a {
 }
 #output .event-block:last-of-type { border-bottom: none; }
 
+#output .cal-btn {
+  font-family: inherit;
+  font-size: inherit;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.2s ease;
+}
+#output .cal-btn:hover { color: var(--text); }
+
 /* Typing cursor for output */
 #output .typing-cursor::after {
   content: "\2588";


### PR DESCRIPTION
Each hackathon in the list command now shows a [+ calendario] button that generates an .ics file client-side and opens it directly in the user's calendar app (Apple Calendar, Google Calendar, Outlook, etc).