### PR TITLE
fix: improve mobile responsiveness across terminal UI

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -4,9 +4,8 @@ const year = new Date().getFullYear();
 
 <footer class="footer">
   <p class="meta">Hecho en Argentina | {year}</p>
-  <p class="meta">
+  <p class="meta links">
     <a href="/submit">$ hackathons-ar --submit</a>
-    &nbsp;&nbsp;
     <a href="https://github.com/ainponce/hackathones" target="_blank" rel="noopener noreferrer"
       >github.com/ainponce/hackathones</a
     >
@@ -23,6 +22,12 @@ const year = new Date().getFullYear();
   .meta {
     color: var(--muted);
     font-size: var(--font-size-sm);
+  }
+
+  .links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem 1rem;
   }
 
   .meta a {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -516,7 +516,7 @@ const sorted = filtered.sort((a, b) => {
         if (actionsHtml) actionsHtml += '  ';
         actionsHtml += '<button class="cal-btn" data-ics="' + icsId + '">[+ google cal]</button>';
       }
-      if (actionsHtml) html += '<div>' + actionsHtml + '</div>';
+      if (actionsHtml) html += '<div class="event-actions">' + actionsHtml + '</div>';
 
       html += '</div>';
       print(html);
@@ -531,15 +531,15 @@ const sorted = filtered.sort((a, b) => {
       await typePrint([
         '<span class="bold">comandos disponibles:</span>',
         '',
-        '  list                       listar todos los hackathones',
-        '  list --pais &lt;pais&gt;         filtrar por pais',
-        '  list --ciudad &lt;ciudad&gt;     filtrar por ciudad',
-        '  list --tipo &lt;tipo&gt;         filtrar por tipo (presencial/online/hibrido)',
-        '  list --tag &lt;tag&gt;           filtrar por tag',
-        '  submit                     enviar un hackathon nuevo',
-        '  clear                      limpiar la terminal',
-        '  about                      sobre este proyecto',
-        '  help                       mostrar esta ayuda',
+        '  list <span class="muted">— listar todos los hackathones</span>',
+        '  list --pais &lt;pais&gt; <span class="muted">— filtrar por pais</span>',
+        '  list --ciudad &lt;ciudad&gt; <span class="muted">— filtrar por ciudad</span>',
+        '  list --tipo &lt;tipo&gt; <span class="muted">— filtrar por tipo</span>',
+        '  list --tag &lt;tag&gt; <span class="muted">— filtrar por tag</span>',
+        '  submit <span class="muted">— enviar un hackathon nuevo</span>',
+        '  clear <span class="muted">— limpiar la terminal</span>',
+        '  about <span class="muted">— sobre este proyecto</span>',
+        '  help <span class="muted">— mostrar esta ayuda</span>',
       ].join('\n'), null, 4);
     }
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -93,6 +93,13 @@ a {
 }
 #output .event-block:last-of-type { border-bottom: none; }
 
+#output .event-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 1rem;
+  align-items: baseline;
+}
+
 #output .cal-btn {
   font-family: inherit;
   font-size: inherit;
@@ -100,7 +107,8 @@ a {
   border: none;
   color: var(--muted);
   cursor: pointer;
-  padding: 0;
+  padding: 0.5rem 0;
+  margin: -0.5rem 0;
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: color 0.2s ease;

--- a/web/src/styles/variables.css
+++ b/web/src/styles/variables.css
@@ -11,3 +11,11 @@
   --terminal-padding: 2rem;
   --max-width: 760px;
 }
+
+@media (max-width: 480px) {
+  :root {
+    --terminal-padding: 1rem;
+    --font-size-base: 13px;
+    --font-size-sm: 11px;
+  }
+}


### PR DESCRIPTION
- Add mobile breakpoint (480px) reducing padding and font sizes
- Wrap URL + calendar button on narrow screens via flex-wrap
- Reformat help command to flow naturally without fixed-width columns
- Increase calendar button tap target to meet 44px minimum
- Use flex layout for footer links to allow natural wrapping