### PR TITLE
fix: allow skipping optional fields and fix text wrapping in submit form

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -368,7 +368,7 @@ const sorted = filtered.sort((a, b) => {
     <div id="input-line">
       <span class="prompt">$&nbsp;</span>
       <div class="input-wrap">
-        <input id="cmd" type="text" autofocus autocomplete="off" spellcheck="false" />
+        <textarea id="cmd" rows="1" autofocus autocomplete="off" spellcheck="false"></textarea>
         <div class="ghost-overlay" id="ghost-overlay" aria-hidden="true">
           <span id="ghost-mirror"></span><span id="autocomplete-ghost" class="autocomplete-ghost"></span>
         </div>
@@ -897,7 +897,6 @@ const sorted = filtered.sort((a, b) => {
 
     async function handleCommand(raw) {
       const trimmed = raw.trim();
-      if (!trimmed) return;
 
       if (submitState !== null) {
         lockInput();
@@ -905,6 +904,8 @@ const sorted = filtered.sort((a, b) => {
         unlockInput();
         return;
       }
+
+      if (!trimmed) return;
 
       printRaw("$ " + trimmed, "bold");
       br();
@@ -962,7 +963,12 @@ const sorted = filtered.sort((a, b) => {
       ghostMirror.textContent = cmdInput.value;
     }
 
-    cmdInput.addEventListener("input", () => updateSuggestion());
+    function autoResize() {
+      cmdInput.style.height = "auto";
+      cmdInput.style.height = cmdInput.scrollHeight + "px";
+    }
+
+    cmdInput.addEventListener("input", () => { updateSuggestion(); autoResize(); });
 
     cmdInput.addEventListener("keydown", (e) => {
       if (e.key === "Tab") {
@@ -987,9 +993,11 @@ const sorted = filtered.sort((a, b) => {
         return;
       }
       if (isTyping) { e.preventDefault(); return; }
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
         const val = cmdInput.value;
         cmdInput.value = "";
+        cmdInput.style.height = "auto";
         suggestion = "";
         updateSuggestion();
         handleCommand(val);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -124,7 +124,7 @@ a {
 /* Input */
 #input-line {
   display: flex;
-  align-items: center;
+  align-items: start;
   margin-top: 0.5rem;
   background: var(--bg);
   padding: 0.25rem 0;
@@ -140,15 +140,20 @@ a {
   font-weight: 400;
 }
 
-#input-line input {
+#input-line textarea {
   font-family: var(--font-mono);
   font-size: var(--font-size-base);
   background: none;
   color: var(--text);
   border: none;
   outline: none;
-  flex: 1;
+  width: 100%;
   caret-color: var(--text);
+  resize: none;
+  overflow: hidden;
+  line-height: 1.4;
+  padding: 0;
+  word-break: break-word;
 }
 
 #input-line .input-wrap {
@@ -161,15 +166,12 @@ a {
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
   pointer-events: none;
   white-space: nowrap;
   overflow: hidden;
   font-family: var(--font-mono);
   font-size: var(--font-size-base);
-  line-height: inherit;
-  display: flex;
-  align-items: center;
+  line-height: 1.4;
 }
 
 #input-line #ghost-mirror {
@@ -185,13 +187,11 @@ a {
   position: absolute;
   left: 0;
   top: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
   color: #ccc;
   pointer-events: none;
   white-space: nowrap;
   overflow: hidden;
+  line-height: 1.4;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
Enter on empty input now correctly advances optional steps (fecha fin, lugar, tags). Replaced single-line input with auto-resizing textarea so long descriptions wrap instead of scrolling off-screen.