### PR TITLE
Security hardening + i18n + Devpost ingest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,18 +5,21 @@ on:
     branches: [main]
     paths: ["web/**"]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -7,6 +7,10 @@ on:
   issues:
     types: [opened, edited, reopened, closed, labeled, unlabeled]
 
+permissions:
+  contents: read
+  issues: read
+
 concurrency:
   group: ingest
   cancel-in-progress: false
@@ -20,13 +24,13 @@ jobs:
       contains(github.event.issue.title, '[lfg]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/supabase/migrations/20260413120000_enable_rls.sql
+++ b/supabase/migrations/20260413120000_enable_rls.sql
@@ -1,0 +1,11 @@
+-- Tighten RLS policies: remove open INSERT policies that allowed
+-- unauthenticated writes via the anon key. The submit flow creates
+-- GitHub Issues (not direct DB inserts), and the ingest pipeline
+-- uses service_role which bypasses RLS, so no public INSERT access
+-- is needed.
+--
+-- RLS was already enabled and SELECT policies ("Public read approved *")
+-- already existed via the Supabase dashboard.
+
+DROP POLICY IF EXISTS "Anyone can submit hackathons" ON public.hackathons;
+DROP POLICY IF EXISTS "Anyone can submit lfg" ON public.lfg_posts;

--- a/supabase/migrations/20260413200000_lock_function_search_path.sql
+++ b/supabase/migrations/20260413200000_lock_function_search_path.sql
@@ -1,0 +1,3 @@
+-- Lock search_path on update_updated_at trigger function to prevent
+-- a malicious schema from shadowing `now()` or other builtins.
+ALTER FUNCTION public.update_updated_at() SET search_path = public, pg_temp;

--- a/supabase/migrations/20260413200100_drop_admin_policies.sql
+++ b/supabase/migrations/20260413200100_drop_admin_policies.sql
@@ -1,0 +1,8 @@
+-- "Admin full access *" policies target role {public} with
+-- auth.role() = 'authenticated' — but this project has no user auth
+-- (only anon + service_role). They never match anyone, but trigger
+-- Supabase linter warnings (multiple_permissive_policies +
+-- auth_rls_initplan). Service role bypasses RLS natively so the
+-- ingest pipeline is unaffected.
+DROP POLICY IF EXISTS "Admin full access hackathons" ON public.hackathons;
+DROP POLICY IF EXISTS "Admin full access lfg" ON public.lfg_posts;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co https://va.vercel-scripts.com; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(self), geolocation=(), payment=()"
+        }
+      ]
+    }
+  ]
+}

--- a/web/package.json
+++ b/web/package.json
@@ -12,12 +12,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/react": "^5.0.2",
+    "@astrojs/react": "^5.0.3",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@supabase/supabase-js": "^2.101.1",
     "@vercel/analytics": "^2.0.1",
-    "astro": "^6.1.1",
+    "astro": "^6.1.6",
     "leva": "^0.10.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -29,5 +29,11 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.183.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "defu@<6.1.5": ">=6.1.5",
+      "vite@>=7.0.0 <7.3.2": ">=7.3.2 <8"
+    }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,13 +4,17 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  defu@<6.1.5: '>=6.1.5'
+  vite@>=7.0.0 <7.3.2: '>=7.3.2 <8'
+
 importers:
 
   .:
     dependencies:
       '@astrojs/react':
-        specifier: ^5.0.2
-        version: 5.0.2(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^5.0.3
+        version: 5.0.3(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.183.2))(@types/react@19.2.14)(@types/three@0.183.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.183.2)
@@ -24,8 +28,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1(react@19.2.4)
       astro:
-        specifier: ^6.1.1
-        version: 6.1.1(@types/node@25.5.2)(rollup@4.60.0)
+        specifier: ^6.1.6
+        version: 6.1.6(@types/node@25.5.2)(rollup@4.60.0)
       leva:
         specifier: ^0.10.1
         version: 0.10.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -70,8 +74,8 @@ packages:
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
     engines: {node: '>=22.12.0'}
 
-  '@astrojs/react@5.0.2':
-    resolution: {integrity: sha512-BDpPrapV3Wgp9sD7aTMvP+ORH0jFEue9OmkBu98KcBbTlsQCnvisDW3m7PQrMptXwEDlX5HGfP/CHmkEVY2tZA==}
+  '@astrojs/react@5.0.3':
+    resolution: {integrity: sha512-z6JXjgADH4/7e0hqcRj+dO9UQlrKmsm2ZJoVT1GzOTYY0ThQ3Znpfr8tY8XKlEHWSTUlT9LP5u4v6QpEJwLz5A==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
@@ -1144,7 +1148,7 @@ packages:
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: '>=7.3.2 <8'
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
@@ -1167,8 +1171,8 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
-  astro@6.1.1:
-    resolution: {integrity: sha512-vq8sHpu1JsY1fWAunn+tdKNbVDmLQNiVdyuGsVT2csgITdFGXXVAyEXFWc1DzkMN0ehElPeiHnqItyQOJK+GqA==}
+  astro@6.1.6:
+    resolution: {integrity: sha512-pRsz+kYriwCV/AUcY/I9OVKtVHuYFs2DtCszAxprXded/kTE53nMwxfnK0Nf6FPfaX9vcUiLnigcSIhuFoKntA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1312,8 +1316,8 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2256,8 +2260,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2299,7 +2303,7 @@ packages:
   vitefu@1.1.2:
     resolution: {integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
+      vite: '>=7.3.2 <8'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2434,17 +2438,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.2(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@astrojs/react@5.0.3(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@25.5.2))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@25.5.2))
       devalue: 5.6.4
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
-      vite: 7.3.1(@types/node@25.5.2)
+      vite: 7.3.2(@types/node@25.5.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3345,7 +3349,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@25.5.2))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.5.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3353,7 +3357,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.5.2)
+      vite: 7.3.2(@types/node@25.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3372,7 +3376,7 @@ snapshots:
 
   assign-symbols@1.0.0: {}
 
-  astro@6.1.1(@types/node@25.5.2)(rollup@4.60.0):
+  astro@6.1.6(@types/node@25.5.2)(rollup@4.60.0):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -3390,7 +3394,6 @@ snapshots:
       cookie: 1.1.1
       devalue: 5.6.4
       diff: 8.0.4
-      dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 2.0.0
       esbuild: 0.27.4
@@ -3424,8 +3427,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@25.5.2)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@25.5.2))
+      vite: 7.3.2(@types/node@25.5.2)
+      vitefu: 1.1.2(vite@7.3.2(@types/node@25.5.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -3584,7 +3587,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   dequal@2.0.3: {}
 
@@ -3724,7 +3727,7 @@ snapshots:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
@@ -4811,7 +4814,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@25.5.2):
+  vite@7.3.2(@types/node@25.5.2):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4823,9 +4826,9 @@ snapshots:
       '@types/node': 25.5.2
       fsevents: 2.3.3
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@25.5.2)):
+  vitefu@1.1.2(vite@7.3.2(@types/node@25.5.2)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.2)
+      vite: 7.3.2(@types/node@25.5.2)
 
   web-namespaces@2.0.1: {}
 

--- a/web/scripts/ingest.mjs
+++ b/web/scripts/ingest.mjs
@@ -82,6 +82,9 @@ const DEVPOST_HEADERS = {
 // runaway `total_count` can't starve the job or trigger rate limits.
 const DEVPOST_PER_PAGE = 40;
 const DEVPOST_MAX_PAGES = 10;
+
+// Same safety net for DoraHacks. page_size=200 × 10 = 2000 events/run.
+const DORAHACKS_MAX_PAGES = 10;
 // Delay between Devpost page fetches. Low enough to finish in a few seconds
 // for typical `total_count` (~100–200), high enough that the AWS ALB in
 // front of Devpost doesn't flag a burst as automated traffic.
@@ -185,6 +188,34 @@ function normalizeType(t) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isHttpUrl(str) {
+  if (!str || typeof str !== "string") return false;
+  try {
+    return ["http:", "https:"].includes(new URL(str).protocol);
+  } catch {
+    return false;
+  }
+}
+
+// Cap a tag/skill array: drop non-strings, truncate each item, and limit
+// overall count. Protects the DB from a compromised or misbehaving source
+// returning thousands of tags or multi-kilobyte strings.
+function capArray(arr, maxItems = 20, maxLen = 50) {
+  if (!Array.isArray(arr)) return [];
+  return arr
+    .filter((s) => typeof s === "string")
+    .map((s) => s.slice(0, maxLen))
+    .slice(0, maxItems);
+}
+
+function fetchWithTimeout(url, opts = {}, ms = 30000) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), ms);
+  return fetch(url, { ...opts, signal: controller.signal }).finally(() =>
+    clearTimeout(id)
+  );
 }
 
 // Devpost returns `submission_period_dates` as a human-readable string in
@@ -316,7 +347,7 @@ async function fetchLumaEvents() {
   const results = await Promise.all(
     LUMA_SEED_SLUGS.map(async (slug) => {
       try {
-        const res = await fetch(`https://api.lu.ma/url?url=${slug}`);
+        const res = await fetchWithTimeout(`https://api.lu.ma/url?url=${slug}`);
         if (!res.ok) return null;
         const data = await res.json();
         const event = data?.data?.event;
@@ -358,18 +389,21 @@ async function fetchDoraHacksEvents() {
   const events = [];
   const pageSize = 200;
   try {
-    const firstRes = await fetch(
+    const firstRes = await fetchWithTimeout(
       `https://dorahacks.io/api/hackathon/?page=1&page_size=${pageSize}`,
       { headers: DORAHACKS_HEADERS }
     );
     if (!firstRes.ok) return events;
     const firstData = await firstRes.json();
-    const totalPages = Math.ceil((firstData.count || 0) / pageSize);
+    const totalPages = Math.min(
+      DORAHACKS_MAX_PAGES,
+      Math.max(1, Math.ceil((firstData.count || 0) / pageSize))
+    );
 
     const pagePromises = [Promise.resolve(firstData)];
     for (let page = 2; page <= totalPages; page++) {
       pagePromises.push(
-        fetch(
+        fetchWithTimeout(
           `https://dorahacks.io/api/hackathon/?page=${page}&page_size=${pageSize}`,
           { headers: DORAHACKS_HEADERS }
         )
@@ -402,9 +436,11 @@ async function fetchDoraHacksEvents() {
         .replace(/\n{2,}/g, " ")
         .trim()
         .slice(0, 300);
-      const tags = h.field
-        ? h.field.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean)
-        : [];
+      const tags = capArray(
+        h.field
+          ? h.field.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean)
+          : []
+      );
       events.push({
         slug: `dorahacks-${h.id}`,
         name: h.title,
@@ -445,7 +481,7 @@ async function fetchDevpostEvents() {
     const buildUrl = (page) =>
       `https://devpost.com/api/hackathons?status=upcoming&per_page=${DEVPOST_PER_PAGE}&page=${page}`;
 
-    const first = await fetch(buildUrl(1), { headers: DEVPOST_HEADERS });
+    const first = await fetchWithTimeout(buildUrl(1), { headers: DEVPOST_HEADERS });
     if (!first.ok) {
       console.warn(`[devpost] page 1 failed: ${first.status}`);
       return events;
@@ -463,7 +499,7 @@ async function fetchDevpostEvents() {
     for (let page = 2; page <= totalPages; page++) {
       await sleep(DEVPOST_PAGE_DELAY_MS);
       try {
-        const res = await fetch(buildUrl(page), { headers: DEVPOST_HEADERS });
+        const res = await fetchWithTimeout(buildUrl(page), { headers: DEVPOST_HEADERS });
         if (!res.ok) {
           console.warn(`[devpost] page ${page} failed: ${res.status}`);
           break;
@@ -509,11 +545,13 @@ async function fetchDevpostEvents() {
 
     const country = isOnline ? "Online" : extractDevpostCountry(locText);
 
-    const tags = Array.isArray(h.themes)
-      ? h.themes
-          .map((t) => (t?.name || "").toLowerCase().trim())
-          .filter(Boolean)
-      : [];
+    const tags = capArray(
+      Array.isArray(h.themes)
+        ? h.themes
+            .map((t) => (t?.name || "").toLowerCase().trim())
+            .filter(Boolean)
+        : []
+    );
 
     // Devpost wraps currency values in an HTML `<span>` like
     // `$<span data-currency-value>20,000</span>`. Strip tags for a clean
@@ -541,7 +579,7 @@ async function fetchDevpostEvents() {
       country,
       city: null,
       location: isOnline ? null : locText || null,
-      url: h.url || null,
+      url: isHttpUrl(h.url) ? h.url : null,
       source: "devpost",
       type,
       tags,
@@ -554,22 +592,39 @@ async function fetchDevpostEvents() {
 }
 
 async function fetchGitHubIssues() {
-  // Fetch once, parse both [hackathon] and [lfg] entries. Also track the
-  // slugs/source_keys we saw so the caller can soft-delete anything in DB
-  // that's no longer present (i.e. the issue was closed / deleted).
+  // Fetch all open issues, paginating via the Link header, then parse both
+  // [hackathon] and [lfg] entries. Also track the slugs/source_keys we saw
+  // so the caller can soft-delete anything in DB that's no longer present
+  // (i.e. the issue was closed / deleted).
+  //
+  // Cap at 10 pages (1000 issues) as a safety net — if the repo ever holds
+  // more than that, switch to a search-based API rather than paging the
+  // whole issue list.
+  const GITHUB_MAX_PAGES = 10;
   try {
-    const res = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO}/issues?state=open&per_page=100`,
-      { headers: GITHUB_HEADERS }
-    );
-    if (!res.ok)
-      return {
-        hackathons: [],
-        lfg: [],
-        seenHackSlugs: new Set(),
-        seenLfgSourceKeys: new Set(),
-      };
-    const issues = await res.json();
+    const allIssues = [];
+    let url =
+      `https://api.github.com/repos/${GITHUB_REPO}/issues?state=open&per_page=100`;
+    for (let page = 0; page < GITHUB_MAX_PAGES && url; page++) {
+      const res = await fetchWithTimeout(url, { headers: GITHUB_HEADERS });
+      if (!res.ok) {
+        return {
+          hackathons: [],
+          lfg: [],
+          seenHackSlugs: new Set(),
+          seenLfgSourceKeys: new Set(),
+          fetchSucceeded: false,
+        };
+      }
+      const pageIssues = await res.json();
+      if (!Array.isArray(pageIssues)) break;
+      allIssues.push(...pageIssues);
+      // GitHub returns e.g. `<https://.../issues?page=2>; rel="next", <...>; rel="last"`
+      const linkHeader = res.headers.get("link") || "";
+      const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+      url = nextMatch ? nextMatch[1] : null;
+    }
+    const issues = allIssues;
     const hackathons = [];
     const lfg = [];
     const seenHackSlugs = new Set();
@@ -627,21 +682,24 @@ async function fetchGitHubIssues() {
         if (date_end && date_end < today) continue;
 
         const tagsRaw = field("Tags");
-        const tags = tagsRaw
-          ? tagsRaw.split(/,\s*/).map((t) => t.trim()).filter(Boolean)
-          : [];
+        const tags = capArray(
+          tagsRaw
+            ? tagsRaw.split(/,\s*/).map((t) => t.trim()).filter(Boolean)
+            : []
+        );
         const descMatch = body.match(/###\s*(?:Description|Descripcion)\s*\n+([\s\S]*?)$/i);
         const description = descMatch ? descMatch[1].trim().slice(0, 300) : "";
 
+        const rawUrl = bilingualField("URL", "URL", "Event URL", "URL del evento");
         hackathons.push({
           slug: `gh-${issue.number}`,
-          name: title.replace(/^\[hackathon\]\s*/i, "").trim(),
+          name: title.replace(/^\[hackathon\]\s*/i, "").trim().slice(0, 200),
           date_start,
           date_end,
-          country: bilingualField("Country", "Pais"),
-          city: bilingualField("City", "Ciudad"),
-          location: bilingualField("Venue", "Lugar"),
-          url: bilingualField("URL", "URL", "Event URL", "URL del evento"),
+          country: (bilingualField("Country", "Pais") || "").slice(0, 100) || null,
+          city: (bilingualField("City", "Ciudad") || "").slice(0, 100) || null,
+          location: (bilingualField("Venue", "Lugar") || "").slice(0, 200) || null,
+          url: isHttpUrl(rawUrl) ? rawUrl : null,
           source: "comunidad",
           type: normalizeType(bilingualField("Type", "Tipo")),
           tags,
@@ -650,21 +708,25 @@ async function fetchGitHubIssues() {
         });
       } else if (lower.startsWith("[lfg]")) {
         seenLfgSourceKeys.add(`gh-${issue.number}`);
-        const handle =
+        const handle = (
           field("Handle", "Your name or handle") ||
           field("Handle", "Tu nombre o alias") ||
-          title.replace(/^\[lfg\]\s*/i, "").trim();
+          title.replace(/^\[lfg\]\s*/i, "").trim()
+        ).slice(0, 100);
         const skillsRaw =
           field("Skills", "Skills (comma-separated)") ||
           field("Skills", "Skills (separados por coma)");
-        const skills = skillsRaw
-          ? skillsRaw.split(/,\s*/).map((s) => s.trim()).filter(Boolean)
-          : [];
+        const skills = capArray(
+          skillsRaw
+            ? skillsRaw.split(/,\s*/).map((s) => s.trim()).filter(Boolean)
+            : []
+        );
         const hackathon = field("Hackathon") || "";
-        const contact =
+        const contact = (
           field("Contact", "Contact (twitter, discord, telegram, email)") ||
           field("Contacto", "Contacto (twitter, discord, telegram, email)") ||
-          "";
+          ""
+        ).slice(0, 200);
         const message = (
           field("Message", "Message (optional)") ||
           field("Mensaje", "Mensaje (opcional)") ||
@@ -675,14 +737,14 @@ async function fetchGitHubIssues() {
           source_key: `gh-${issue.number}`,
           handle,
           skills,
-          hackathon_name: hackathon,
+          hackathon_name: hackathon.slice(0, 200),
           contact,
           message,
           status: issueStatus,
         });
       }
     }
-    return { hackathons, lfg, seenHackSlugs, seenLfgSourceKeys };
+    return { hackathons, lfg, seenHackSlugs, seenLfgSourceKeys, fetchSucceeded: true };
   } catch (e) {
     console.warn("GitHub fetch failed:", e.message);
     return {
@@ -690,6 +752,7 @@ async function fetchGitHubIssues() {
       lfg: [],
       seenHackSlugs: new Set(),
       seenLfgSourceKeys: new Set(),
+      fetchSucceeded: false,
     };
   }
 }
@@ -757,35 +820,42 @@ async function main() {
   // Soft-delete: any comunidad hackathon in DB that we didn't see in the
   // current GitHub fetch (= the issue was closed or deleted). Mark as
   // rejected so it disappears from the home but stays auditable.
-  const { data: existingComunidad, error: hSelectError } = await supabase
-    .from("hackathons")
-    .select("slug")
-    .eq("source", "comunidad");
-  if (hSelectError) {
-    console.warn(
-      "[ingest] could not load existing comunidad slugs:",
-      hSelectError.message
-    );
+  //
+  // Skip when the GitHub fetch failed — otherwise a transient outage would
+  // leave `seenHackSlugs` empty and mass-reject every comunidad hackathon.
+  if (!ghResult.fetchSucceeded) {
+    console.warn("[ingest] skipping comunidad soft-delete because GitHub fetch failed");
   } else {
-    const disappeared = (existingComunidad || [])
-      .map((r) => r.slug)
-      .filter((s) => !ghResult.seenHackSlugs.has(s));
-    if (disappeared.length) {
-      console.log(
-        `[ingest] soft-deleting ${disappeared.length} disappeared comunidad hackathons`
+    const { data: existingComunidad, error: hSelectError } = await supabase
+      .from("hackathons")
+      .select("slug")
+      .eq("source", "comunidad");
+    if (hSelectError) {
+      console.warn(
+        "[ingest] could not load existing comunidad slugs:",
+        hSelectError.message
       );
-      const { error: hSoftError } = await supabase
-        .from("hackathons")
-        .update({
-          status: "rejected",
-          updated_at: new Date().toISOString(),
-        })
-        .in("slug", disappeared);
-      if (hSoftError) {
-        console.warn(
-          "[ingest] comunidad soft-delete failed:",
-          hSoftError.message
+    } else {
+      const disappeared = (existingComunidad || [])
+        .map((r) => r.slug)
+        .filter((s) => !ghResult.seenHackSlugs.has(s));
+      if (disappeared.length) {
+        console.log(
+          `[ingest] soft-deleting ${disappeared.length} disappeared comunidad hackathons`
         );
+        const { error: hSoftError } = await supabase
+          .from("hackathons")
+          .update({
+            status: "rejected",
+            updated_at: new Date().toISOString(),
+          })
+          .in("slug", disappeared);
+        if (hSoftError) {
+          console.warn(
+            "[ingest] comunidad soft-delete failed:",
+            hSoftError.message
+          );
+        }
       }
     }
   }
@@ -811,29 +881,34 @@ async function main() {
   }
 
   // Soft-delete lfg_posts whose source_key disappeared from the open issues.
-  const { data: existingLfg, error: lSelectError } = await supabase
-    .from("lfg_posts")
-    .select("source_key")
-    .not("source_key", "is", null);
-  if (lSelectError) {
-    console.warn(
-      "[ingest] could not load existing lfg source_keys:",
-      lSelectError.message
-    );
+  // Same guard as above — don't mass-reject on a transient GitHub outage.
+  if (!ghResult.fetchSucceeded) {
+    console.warn("[ingest] skipping lfg soft-delete because GitHub fetch failed");
   } else {
-    const disappearedLfg = (existingLfg || [])
-      .map((r) => r.source_key)
-      .filter((s) => s && !ghResult.seenLfgSourceKeys.has(s));
-    if (disappearedLfg.length) {
-      console.log(
-        `[ingest] soft-deleting ${disappearedLfg.length} disappeared lfg posts`
+    const { data: existingLfg, error: lSelectError } = await supabase
+      .from("lfg_posts")
+      .select("source_key")
+      .not("source_key", "is", null);
+    if (lSelectError) {
+      console.warn(
+        "[ingest] could not load existing lfg source_keys:",
+        lSelectError.message
       );
-      const { error: lSoftError } = await supabase
-        .from("lfg_posts")
-        .update({ status: "rejected" })
-        .in("source_key", disappearedLfg);
-      if (lSoftError) {
-        console.warn("[ingest] lfg soft-delete failed:", lSoftError.message);
+    } else {
+      const disappearedLfg = (existingLfg || [])
+        .map((r) => r.source_key)
+        .filter((s) => s && !ghResult.seenLfgSourceKeys.has(s));
+      if (disappearedLfg.length) {
+        console.log(
+          `[ingest] soft-deleting ${disappearedLfg.length} disappeared lfg posts`
+        );
+        const { error: lSoftError } = await supabase
+          .from("lfg_posts")
+          .update({ status: "rejected" })
+          .in("source_key", disappearedLfg);
+        if (lSoftError) {
+          console.warn("[ingest] lfg soft-delete failed:", lSoftError.message);
+        }
       }
     }
   }

--- a/web/src/components/Terminal.astro
+++ b/web/src/components/Terminal.astro
@@ -29,7 +29,7 @@ const LOCALE = locale;
     <div id="input-line">
       <span class="prompt">$&nbsp;</span>
       <div class="input-wrap">
-        <textarea id="cmd" rows="1" autofocus autocomplete="off" spellcheck="false"></textarea>
+        <textarea id="cmd" rows="1" maxlength="2000" autofocus autocomplete="off" spellcheck="false"></textarea>
         <div class="ghost-overlay" id="ghost-overlay" aria-hidden="true">
           <span id="ghost-mirror"></span><span id="autocomplete-ghost" class="autocomplete-ghost"></span>
         </div>
@@ -78,8 +78,13 @@ const LOCALE = locale;
           apikey: SUPABASE_ANON_KEY,
           Authorization: "Bearer " + SUPABASE_ANON_KEY,
         };
-        const hackUrl = SUPABASE_URL + "/rest/v1/hackathons?select=*&status=eq.approved&or=(date_end.is.null,date_end.gte." + TODAY + ")&order=date_start.asc.nullslast";
-        const lfgUrl = SUPABASE_URL + "/rest/v1/lfg_posts?select=*&status=eq.approved&order=created_at.desc";
+        // Explicit column lists (data minimization): request only the fields the
+        // mapper below actually consumes, so any future schema column isn't auto-
+        // exposed to the anon key.
+        const HACK_COLS = "slug,name,date_start,date_end,country,city,location,url,source,type,tags,description";
+        const LFG_COLS = "id,handle,skills,hackathon_name,contact,message,created_at";
+        const hackUrl = SUPABASE_URL + "/rest/v1/hackathons?select=" + HACK_COLS + "&status=eq.approved&or=(date_end.is.null,date_end.gte." + TODAY + ")&order=date_start.asc.nullslast";
+        const lfgUrl = SUPABASE_URL + "/rest/v1/lfg_posts?select=" + LFG_COLS + "&status=eq.approved&order=created_at.desc";
         const [hackRes, lfgRes] = await Promise.all([
           fetch(hackUrl, { headers: commonHeaders }),
           fetch(lfgUrl, { headers: commonHeaders }),
@@ -114,7 +119,7 @@ const LOCALE = locale;
           };
         });
       } catch (e) {
-        console.error("[supabase] fetch failed:", e);
+        console.error("[supabase] fetch failed:", e && e.message ? e.message : e);
       }
     }
 
@@ -200,6 +205,14 @@ const LOCALE = locale;
       return d.innerHTML;
     }
 
+    function safeHref(url) {
+      try {
+        var p = new URL(url, location.href).protocol;
+        if (p === "http:" || p === "https:") return url;
+      } catch (e) {}
+      return "#";
+    }
+
     // Date formatting uses the active locale. The BCP-47 tag we pass to
     // toLocaleDateString is derived from LOCALE: 'en' → 'en-US', 'es' → 'es-AR'
     // (since Argentine Spanish is the copy style we optimize for), 'pt' →
@@ -258,7 +271,7 @@ const LOCALE = locale;
       if (h.description) html += '<div>' + esc(h.description) + '</div>';
 
       let actionsHtml = '';
-      if (h.url) actionsHtml += '<a class="link" href="' + esc(h.url) + '" target="_blank" rel="noopener">' + esc(h.url) + '</a>';
+      if (h.url) actionsHtml += '<a class="link" href="' + esc(safeHref(h.url)) + '" target="_blank" rel="noopener">' + esc(h.url) + '</a>';
       if (h.date_start) {
         if (actionsHtml) actionsHtml += '  ';
         actionsHtml += '<button class="cal-btn" data-ics="' + icsId + '">' + t("event.action.calendar") + '</button>';


### PR DESCRIPTION
## Summary

Branch bundles three bodies of work that were prepared in sequence:

1. **i18n support** (en/es/pt) and terminal refactor (`9ef525a`)
2. **Devpost ingest** as a fourth source + legacy Python scraper cleanup (`4fbf965`)
3. **Security hardening** across four audit rounds (`b383049`, `193119b`, `801ee35`, `b59ddbc`)

### Security hardening — what changed

**Dependencies** (`b383049`)
- Closed 4 CVEs (defu prototype pollution HIGH; two vite path-traversal MODERATE)
- Bumped astro 6.1.1 → 6.1.6 and @astrojs/react 5.0.2 → 5.0.3
- Added `pnpm.overrides` to force patched transitive versions
- `pnpm audit` now clean

**Database** (`193119b`)
- Dropped open INSERT policies that let the anon key write directly to PostgREST
- Dropped two "Admin full access" zombie policies (project has no user auth)
- Locked `update_updated_at()` search_path to `public, pg_temp`
- Each table ends with exactly one `Public read approved *` policy
- Supabase linter: 0 performance warnings, only `leaked_password_protection` (N/A — no auth)
- Already applied to production

**Frontend** (`801ee35`)
- `safeHref()` rejects non-http(s) protocols on DB-sourced URLs (blocks `javascript:` XSS vector)
- `maxlength="2000"` on terminal textarea prevents paste-based self-DoS
- `console.error` logs only `e.message`, not full exception object
- PostgREST calls replaced `select=*` with explicit column lists (data minimization)
- New `vercel.json` with CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy

**Ingest + CI** (`b59ddbc`)
- `isHttpUrl()` validation at both DB-entry points (Devpost + GitHub Issues)
- `capArray()` limits tags/skills to 20 items × 50 chars
- `.slice()` caps on all previously unbounded string fields (name, country, city, location, handle, contact, hackathon_name)
- `fetchWithTimeout()` (30s) on all 6 upstream fetches
- `DORAHACKS_MAX_PAGES = 10` mirrors the existing Devpost cap
- GitHub Issues paginated via `Link: rel="next"` (previously dropped issues beyond #100)
- `fetchSucceeded` flag guards the soft-delete blocks — transient GitHub outages no longer mass-reject the `comunidad` source
- Workflows get least-privilege `permissions:` blocks
- Actions pinned to verified SHAs (`actions/checkout@34e11487…` etc.)

## Test plan

- [x] `pnpm build` passes (4 pages built, no warnings)
- [x] `pnpm audit` reports no known vulnerabilities
- [x] Supabase security advisors: 0 actionable
- [x] Supabase performance advisors: 0 warnings
- [x] DB policies verified via pg_policies query (1 per table)
- [x] `update_updated_at` proconfig confirmed `{search_path=public, pg_temp}`
- [x] Spot-check `/`, `/es/`, `/pt/` render and fetch Supabase data
- [x] Confirm the ingest workflow runs cleanly post-merge (cron or manual dispatch)